### PR TITLE
Add flag to enable assert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 script:
   - javac *.java
-  - java Test
+  - java -ea Test


### PR DESCRIPTION
When invoking Jave, the flag -ea is needed or assert statement does not work.

See https://en.m.wikibooks.org/wiki/Java_Programming/Keywords/assert